### PR TITLE
Implement tuple support

### DIFF
--- a/src/interp.rs
+++ b/src/interp.rs
@@ -223,12 +223,14 @@ impl<'a, 'tcx> Machine<'a, 'tcx> {
             Rvalue::Aggregate(ref kind, ref ops) => {
                 match **kind {
                     AggregateKind::Tuple => {
-                        // XXX: Tuple layout needs some proper thought, and
-                        // should be upcoming in the next PR, so we handle the
-                        // empty tuple explicitly as this is the bottom type in
-                        // Rust.
-                        if ops.len() != 0 {
-                            unimplemented!()
+                        if ops.len() == 0 {
+                            return; // Bottom type is empty tuple, and zero-sized.
+                        }
+
+                        let mut vals: Vec<Value> = Vec::new();
+                        for op in ops.iter() {
+                            let val = self.eval_operand(op).val;
+                            vals.push(val);
                         }
                     },
                     _ => unimplemented!()

--- a/src/machine.rs
+++ b/src/machine.rs
@@ -103,7 +103,7 @@ impl<'tcx> Frame<'tcx> {
 #[derive(Debug)]
 pub enum Address {
     Heap(usize), // pointer to offset in memory.
-    Local(Local)
+    Local(Local, usize),
 }
 
 pub struct Memory {
@@ -232,23 +232,25 @@ impl<'a, 'tcx> Machine<'a, 'tcx> {
 
     pub fn store(&mut self, tv: TyVal<'tcx>, dest: Address) {
         match dest {
-            Address::Local(key) => {
+            Address::Local(key, _) => {
                 self.cur_frame_mut().set_local(key, tv.to_bytes())
             },
             Address::Heap(ptr) =>  {
                 self.memory.store(ptr, tv.to_bytes())
-            }
+            },
+            _ => unimplemented!()
         }
     }
 
     pub fn read(&self, dest: Address, size: usize) -> &[u8] {
         match dest {
-            Address::Local(key) => {
+            Address::Local(key, _) => {
                 self.cur_frame().get_local(key)
-            }
+            },
             Address::Heap(ptr) => {
                 self.memory.read(ptr, size)
-            }
+            },
+            _ => unimplemented!()
         }
     }
 }

--- a/tests/compile_pass/simple_tuple.rs
+++ b/tests/compile_pass/simple_tuple.rs
@@ -1,0 +1,3 @@
+fn main() {
+    let x = (13, false);
+}


### PR DESCRIPTION
Attempt 2! Tuple support was previously limited to the bottom type: `()`. This PR allows for full evaluation support of tuples and storing them in memory.

