### PR TITLE
Make frame locals exact sized

### DIFF
--- a/src/interp.rs
+++ b/src/interp.rs
@@ -406,13 +406,22 @@ pub fn size_of<'tcx>(ty: Ty<'tcx>) -> usize {
     use::syntax::ast::IntTy;
     match ty.sty {
         TypeVariants::TyInt(int_ty) => match int_ty {
-            IntTy::I8 => 8,
-            IntTy::I16 => 16,
-            IntTy::I32 => 32,
-            IntTy::I64 => 64,
+            IntTy::I8 => 1,
+            IntTy::I16 => 2,
+            IntTy::I32 => 4,
+            IntTy::I64 => 8,
+            IntTy::I128 => 16,
             _ => unimplemented!(),
         },
-        _ => unimplemented!(),
+        TypeVariants::TyBool => 1,
+        TypeVariants::TyTuple(tys, ..) => {
+            let mut size = 0;
+            for t in tys.iter() {
+                size += size_of(t);
+            }
+            size
+        },
+        _ => unimplemented!("{:?}", ty.sty),
     }
 }
 

--- a/src/interp.rs
+++ b/src/interp.rs
@@ -36,6 +36,7 @@
 
 use byteorder::{ByteOrder, LittleEndian};
 use std::process::exit;
+use std::mem;
 use rustc::ty;
 use rustc::ty::{Ty, TyCtxt, TypeVariants};
 use rustc::hir::def_id::DefId;
@@ -313,6 +314,8 @@ impl<'a, 'tcx> Machine<'a, 'tcx> {
                         // though... Nested field access is turned into local
                         // move's in MIR, so perhaps it's an edge case not worth
                         // worrying about.
+                        assert_ne!(mem::discriminant(&proj.base), mem::discriminant(place));
+
                         match base_addr {
                             Address::Local(local, _) => {
                                 return Address::Local(local, Some(ptr));


### PR DESCRIPTION
The nightly 1.26 change to MIR projections had highlighted to me that the way I was instantiating frame local variables was very inefficient. I've addressed this in this PR.

As it is known statically how much memory is required for each frame, I create zeroed byte vectors for each local which are sized to their exact requirements specified by their type.

Sorry that this is quite a big commit, the changes were quite fundamental and required a lot of outwards refactoring to make work.