### PR TITLE
Removed recursive function calls for evaluation of basic blocks.

### DIFF
--- a/src/machine.rs
+++ b/src/machine.rs
@@ -38,7 +38,7 @@ use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::rc::Rc;
 
 use rustc::hir::def_id::DefId;
-use rustc::mir::{Mir, Local, BasicBlock, Place};
+use rustc::mir::{Mir, Local, BasicBlock, Place, START_BLOCK};
 use rustc::ty::{TyCtxt, Instance, InstanceDef};
 use rustc_data_structures::indexed_vec::{Idx};
 


### PR DESCRIPTION
When a basic block has been interpreted, the address of the next block
is now written to the Machine. Like traditional interpreters, a main
interpreter loop now exists which checks that a `next block` address
always exists.

Before this commit, interpreting of basic blocks would take place
through nested function calls which would stack overflow once maximum
recursion depth was exceeded. This meant that it was not possible to
interpret anything more than non-trivial iteration.